### PR TITLE
modify loginviewmodel

### DIFF
--- a/app/src/main/java/com/segnities007/seg/ui/screens/hub/Hub.kt
+++ b/app/src/main/java/com/segnities007/seg/ui/screens/hub/Hub.kt
@@ -1,0 +1,8 @@
+package com.segnities007.seg.ui.screens.hub
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun Hub(){
+
+}

--- a/app/src/main/java/com/segnities007/seg/ui/screens/login/Login.kt
+++ b/app/src/main/java/com/segnities007/seg/ui/screens/login/Login.kt
@@ -20,7 +20,7 @@ fun Login(
         }
     ) {
         LoginUi(
-            uiState = loginUiState.uiState,
+            uiState = loginUiState.signUiState,
             onEmailChange = loginUiState::onEmailChange,
             onPasswordChange = loginUiState::onPasswordChange,
         )
@@ -29,7 +29,8 @@ fun Login(
 
 @Composable
 private fun LoginUi(
-    uiState: LoginUiState,
+    signUiState: SignUiState,
+    navigateUiState: NavigateUiState,
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
 ){
@@ -37,16 +38,16 @@ private fun LoginUi(
         topBar = {},
         bottomBar = {},
     ){innerPadding ->
-        when(uiState.index){
+        when(navigateUiState.index){
             0 -> SignIn(
                     modifier = Modifier.padding(innerPadding),
-                    uiState = uiState,
+                    uiState = signUiState,
                     onEmailChange = onEmailChange,
                     onPasswordChange = onPasswordChange
                 )
             1 -> SignUp(
                     modifier = Modifier.padding(innerPadding),
-                    uiState = uiState,
+                    uiState = signUiState,
                     onEmailChange = onEmailChange,
                     onPasswordChange = onPasswordChange
                 )

--- a/app/src/main/java/com/segnities007/seg/ui/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/com/segnities007/seg/ui/screens/login/LoginViewModel.kt
@@ -6,27 +6,32 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
 
-data class LoginUiState(
+data class SignUiState(
     val email: String = "",
     val password: String = "",
+)
+
+data class NavigateUiState(
     val index: Int = 0,
 )
 
 class LoginViewModel : ViewModel() {
 
-    var uiState by mutableStateOf(LoginUiState())
+    var signUiState by mutableStateOf(SignUiState())
+        private set
+    var navigateUiState by mutableStateOf(NavigateUiState())
         private set
 
     fun onEmailChange(newEmail: String) {
-        uiState = uiState.copy(email = newEmail)
+        signUiState = signUiState.copy(email = newEmail)
     }
 
     fun onPasswordChange(newPassword: String) {
-        uiState = uiState.copy(password = newPassword)
+        signUiState = signUiState.copy(password = newPassword)
     }
 
     fun onIndexChange(newIndex: Int) {
-        uiState = uiState.copy(index = newIndex)
+        navigateUiState = navigateUiState.copy(index = newIndex)
     }
 
 }

--- a/app/src/main/java/com/segnities007/seg/ui/screens/login/sign_in/SignIn.kt
+++ b/app/src/main/java/com/segnities007/seg/ui/screens/login/sign_in/SignIn.kt
@@ -7,12 +7,12 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.segnities007.seg.ui.screens.login.LoginUiState
+import com.segnities007.seg.ui.screens.login.SignUiState
 
 @Composable
 fun SignIn(// TODO modify ui
     modifier: Modifier = Modifier,
-    uiState: LoginUiState,
+    signUiState: SignUiState,
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
 ){
@@ -21,8 +21,8 @@ fun SignIn(// TODO modify ui
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ){
-        InputForm(text = uiState.email) { onEmailChange(it) }
-        InputForm(text = uiState.password) { onPasswordChange(it) }
+        InputForm(text = signUiState.email) { onEmailChange(it) }
+        InputForm(text = signUiState.password) { onPasswordChange(it) }
     }
 }
 

--- a/app/src/main/java/com/segnities007/seg/ui/screens/login/sign_up/SignUp.kt
+++ b/app/src/main/java/com/segnities007/seg/ui/screens/login/sign_up/SignUp.kt
@@ -7,12 +7,12 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.segnities007.seg.ui.screens.login.LoginUiState
+import com.segnities007.seg.ui.screens.login.SignUiState
 
 @Composable
 fun SignUp(//TODO modify ui
     modifier: Modifier = Modifier,
-    uiState: LoginUiState,
+    signUiState: SignUiState,
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
 ){
@@ -21,8 +21,8 @@ fun SignUp(//TODO modify ui
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ){
-        InputForm(text = uiState.email) { onEmailChange(it) }
-        InputForm(text = uiState.password) { onPasswordChange(it) }
+        InputForm(text = signUiState.email) { onEmailChange(it) }
+        InputForm(text = signUiState.password) { onPasswordChange(it) }
     }
 }
 


### PR DESCRIPTION
index変更による不必要なリコンポースを防ぐため、loginviewmodelにあるdataclassのぷろぱてぃを分けた。
それに伴いコンポーザブル関数の引数の名前等も変更した。